### PR TITLE
Serialport10

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jest": "^23.6.0"
   },
   "peerDependencies": {
-    "serialport": "^6.2.0"
+    "serialport": "10.5.0"
   },
   "devDependencies": {
     "debug": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "lint": "nrfconnect-scripts lint src"
   },
   "dependencies": {
-    "inquirer": "^6.2.0",
-    "jest": "^23.6.0"
+    "inquirer": "^6.2.0"
   },
   "peerDependencies": {
     "serialport": "10.5.0"
   },
   "devDependencies": {
     "debug": "^3.2.6",
+    "jest": "^23.6.0",
     "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v3.1.0",
     "rollup": "^0.50.0",
     "rollup-plugin-commonjs": "^8.2.1",

--- a/src/DTM_transport.js
+++ b/src/DTM_transport.js
@@ -42,7 +42,7 @@
 
 import EventEmitter from 'events';
 
-import SerialPort from 'serialport';
+import { SerialPort } from 'serialport';
 
 // 2 bits
 const DTM_CMD = {
@@ -121,7 +121,7 @@ const cmdToHex = cmd => {
 class DTMTransport extends EventEmitter {
     constructor(comName) {
         super();
-        this.port = new SerialPort(comName, { autoOpen: false, baudRate: 19200 });
+        this.port = new SerialPort({ path: comName, autoOpen: false, baudRate: 19200 });
         this.waitForOpen = null;
         this.addListeners();
     }


### PR DESCRIPTION
When merging, we should still keep the branch `serialport10` intact for now, because unfortunately [`pc-nrfconnect-dtm`](https://github.com/NordicSemiconductor/pc-nrfconnect-dtm/) references that branch.